### PR TITLE
Add common-diagnostics logger

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -17,6 +17,7 @@
 'use strict';
 var env = process.env;
 var commonDiag = require('@google/cloud-diagnostics-common');
+var logger = require('./logger.js');
 var utils = commonDiag.utils;
 var lodash = require('lodash');
 var isPlainObject = lodash.isPlainObject;
@@ -76,6 +77,13 @@ var Configuration = function(givenConfig) {
    * @type {Boolean}
    */
   this._shouldReportErrorsToAPI = env.NODE_ENV === 'production';
+  if (!this._shouldReportErrorsToAPI) {
+    logger.warn([
+      'Stackdriver error reporting client has not been configured to send',
+      'errors, please check the NODE_ENV environment variable and make sure it',
+      'is set to production'
+    ].join(' '));
+  }
   /**
    * The _projectId property is meant to contain the string project id that the
    * hosting application is running under. The project id is a unique string

--- a/lib/google-apis/auth-client.js
+++ b/lib/google-apis/auth-client.js
@@ -16,6 +16,7 @@
 
 'use strict';
 var commonDiag = require('@google/cloud-diagnostics-common');
+var logger = require('../logger.js');
 var lodash = require('lodash');
 var isFunction = lodash.isFunction;
 var isString = lodash.isString;
@@ -66,7 +67,7 @@ function RequestHandler(config) {
  * @private
  */
 function getErrorReportURL(projectId, key) {
-  var url = [ API, projectId, 'events:report'].join('/');
+  var url = [API, projectId, 'events:report'].join('/');
   if (isString(key)) {
     url += '?key=' + key;
   }
@@ -91,18 +92,36 @@ RequestHandler.prototype.sendError = function(errorMessage, userCb) {
     self._config.getProjectId(function (err, id) {
       if (err) {
         setImmediate(function () { cb(err, null, null); });
+        logger.error([
+          'Unable to retrieve a project id from the Google Metadata Service or',
+          'the local environment. Client will not be able to communicate with',
+          'the Stackdriver Error Reporting API without a valid project id', 
+          'Please make sure to supply a project id either throught the'
+          'GCLOUD_PROJECT environmental variable or through the configuration',
+          'object given to this library on startup if not running on Google',
+          'Cloud Platform.'
+        ].join(' '));
         return;
       }
       self._request({
         url: getErrorReportURL(id, self._config.getKey()),
         method: 'POST',
         json: errorMessage
-      }, cb);
+      }, function (err, response, body) {
+        if (err) {
+          logger.error([
+            'Encountered an error while attempting to transmit an error to the',
+            'Stackdriver Error Reporting API.'
+          ].join(' '), err);
+        }
+        cb(err, response, body);
+      });
     });
   } else {
     cb(new Error([
-      'Client has not been configured to send errors, please check the',
-      'NODE_ENV environment variable and make sure it is set to production'
+      'Stackdriver error reporting client has not been configured to send',
+      'errors, please check the NODE_ENV environment variable and make sure it',
+      'is set to production'
     ].join(' ')), null, null);
   }
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,4 @@
+var logger = require('@google/cloud-diagnostics-common').logger;
+var logConfig = process.env.GCLOUD_ERRORS_LOGLEVEL;
+var logLevel = !isNaN(logConfig) ? logConfig : logger.WARN;
+module.exports = logger.create(logLevel, '@google/cloud-errors');


### PR DESCRIPTION
07/30/2016-20:46 PST
Add the common diag logger to the library and replace all console.log
calls with the common diag logger equivalent calls. Add default logging
of errors on init/transaction errors as per #40 when user does not
supply a callback or is using a server plugin. Add tests to address new
behaviour.
Fixes #15 
Fixes #40 

08/12/2016-23:33 PST
Add the Common Diagnostics Logger to the error library and create
logging points for failures in both configuration and interaction with
the Stackdriver Error Reporting API.