### PR TITLE
Remove invocation on import and create configure property

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ applications running in almost any environment. Here's an introductory video:
 
 	```JS
 	// Require the library and initialize the error handler
-	var errors = require('@google/cloud-errors')({
-		serviceContext: {service: 'my-service'}	// not needed on Google App Engine
+	var errors = require('@google/cloud-errors').start({
+		serviceContext: {service: 'my-service'} // not needed on Google App Engine
 	});
 
 	// Report an error to the Stackdriver Error Reporting API
@@ -61,7 +61,7 @@ When initing the Stackdriver Error Reporting library you must specify the follow
 On Google App Engine, these environment variables are already set.
 
 ```JS
-var errors = require('@google/cloud-errors')({
+var errors = require('@google/cloud-errors').start({
 	projectId: 'my-project-id',
 	key: 'my-api-key',
 	keyFilename: 'path-to-my-keyfile'
@@ -78,7 +78,8 @@ var errors = require('@google/cloud-errors')({
 ```JS
 var express = require('express');
 var app = express();
-var errors = require('@google/cloud-errors')();
+// Will create a errors instance based off env variables
+var errors = require('@google/cloud-errors').start();
 
 app.get('/error', function ( req, res, next ) {
     res.send('Something broke!');
@@ -98,7 +99,7 @@ app.listen(3000);
 
 ```JS
 var hapi = require('hapi');
-var errors = require('@google/cloud-errors')();
+var errors = require('@google/cloud-errors').start();
 
 var server = new hapi.Server();
 server.connection({ port: 3000 });
@@ -119,7 +120,7 @@ server.register({ register: errors.hapi });
 ### Using Koa
 
 ```JS
-var errors = require('@google/cloud-errors')();
+var errors = require('@google/cloud-errors').start();
 var koa = require('koa');
 var app = koa();
 
@@ -146,7 +147,7 @@ function respond(req, res, next) {
 }
 
 var restify = require('restify');
-var errors = require('@google/cloud-errors')();
+var errors = require('@google/cloud-errors').start();
 
 var server = restify.createServer();
 

--- a/index.js
+++ b/index.js
@@ -80,4 +80,4 @@ function initializeClientAndInterfaces ( initConfiguration ) {
   };
 }
 
-module.exports = initializeClientAndInterfaces;
+module.exports = {start: initializeClientAndInterfaces};

--- a/tests/test-servers/express_scaffold_server.js
+++ b/tests/test-servers/express_scaffold_server.js
@@ -20,10 +20,10 @@ var lodash = require('lodash');
 var has = lodash.has;
 var express = require('express');
 var app = express();
-var errorHandler = require('../../index.js')({
+var errorHandler = require('../../index.js').start({
   onUncaughtException: 'report',
   key: process.env.STUBBED_API_KEY,
-  projectId: 'ccavalli-test-debug-external'
+  projectId: process.env.STUBBED_PROJECT_NUM
 });
 var bodyParser = require('body-parser');
 

--- a/tests/test-servers/hapi_scaffold_server.js
+++ b/tests/test-servers/hapi_scaffold_server.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 var hapi = require('hapi');
-var errorHandler = require('../../index.js')();
+var errorHandler = require('../../index.js').start();
 
 var server = new hapi.Server();
 server.connection({ port: 3000 });

--- a/tests/test-servers/koa_scaffold_server.js
+++ b/tests/test-servers/koa_scaffold_server.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var errorHandler = require('../../index.js')({
+var errorHandler = require('../../index.js').start({
   onUncaughtException: 'report'
 });
 var koa = require('koa');

--- a/tests/test-servers/manual_scaffold_server.js
+++ b/tests/test-servers/manual_scaffold_server.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var errors = require('../../index.js')();
+var errors = require('../../index.js').start();
 var r = errors.report('Sample string', (err, result) => {
   console.log('callback from report', err, result);
 });

--- a/tests/test-servers/restify_scaffold_server.js
+++ b/tests/test-servers/restify_scaffold_server.js
@@ -19,7 +19,7 @@ function respond(req, res, next) {
 }
 
 var restify = require('restify');
-var errorHandler = require('../../index.js')();
+var errorHandler = require('../../index.js').start();
 
 var server = restify.createServer();
 


### PR DESCRIPTION
Remove the anonymous function invocation required for init and replace
with a plain JS object exported with a start method which calls the
otherwise anonymously invoked function. Update documentation and
relevant tests.

Fixes #26