### PR TITLE
Add timer to uncaught exception reporter for process exit

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -38,6 +38,7 @@ function decryptAcceptanceCredentials {
 function runFullSuite {
   $(npm bin)/istanbul cover -x "fuzzer.js" \
   $(npm bin)/tape ./tests/integration/*.js ./tests/unit/*.js \
+  ./tests/fixtures/*.js \
   --report lcovonly -- -R spec && cat ./coverage/lcov.info \
   | $(npm bin)/coveralls && rm -rf ./coverage
 }

--- a/lib/interfaces/uncaught.js
+++ b/lib/interfaces/uncaught.js
@@ -54,6 +54,7 @@ function handlerSetup(client, config) {
 
     errorHandlerRouter(err, em);
     client.sendError(em, handleProcessExit);
+    setTimeout(handleProcessExit, 2000);
   }
 
   if (config.reportUncaughtExceptions === false) {

--- a/tests/fixtures/uncaughtExitBehaviour.js
+++ b/tests/fixtures/uncaughtExitBehaviour.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var uncaughtSetup = require('../../lib/interfaces/uncaught.js');
+var test = require('tape');
+var nock = require('nock');
+var isString = require('lodash').isString;
+var Configuration = require('../../lib/configuration.js');
+var RequestHandler = require('../../lib/google-apis/auth-client.js');
+var ErrorMessage = require('../../lib/classes/error-message.js');
+var originalHandlers = process.listeners('uncaughtException');
+
+function reattachOriginalListeners ( ) {
+  for (var i = 0; i < originalHandlers.length; i++) {
+    process.on('uncaughtException', originalHandlers[i]);
+  }
+}
+test('Sending behavior when an uncaughtException is encountered', function (t) {
+  process.removeAllListeners('uncaughtException');
+  if (!isString(process.env.GCLOUD_PROJECT)) {
+    t.fail("The gcloud project id (GCLOUD_PROJECT) was not set as an env variable");
+    t.end();
+    process.exit();
+  } else if (!isString(process.env.GOOGLE_APPLICATION_CREDENTIALS)) {
+    t.fail("The app credentials (GOOGLE_APPLICATION_CREDENTIALS) was not set as an env variable");
+    t.end();
+    process.exit();
+  }
+  var s = nock(
+    'https://clouderrorreporting.googleapis.com/v1beta1/projects/'+
+      process.env.GCLOUD_PROJECT
+  ).post('/events:report').once().reply(200, function () {
+    t.pass('The library should attempt to create an entry with the service');
+    reattachOriginalListeners();
+    t.end();
+    return {success: true};
+  });
+  var cfg = new Configuration({reportUncaughtExceptions: true});
+  var client = new RequestHandler(cfg);
+  var uncaught = uncaughtSetup(client, cfg);
+  setImmediate(function () {
+    throw new Error('This error was supposed to be thrown');
+  });
+});

--- a/tests/unit/testConfiguration.js
+++ b/tests/unit/testConfiguration.js
@@ -278,6 +278,7 @@ test(
     var projectId = 'test-123';
     var name = 'test';
     var ver = 'test2';
+    var oldProject = process.env.GCLOUD_PROJECT;
     process.env.GCLOUD_PROJECT = projectId;
     process.env.GAE_MODULE_NAME = name;
     process.env.GAE_MODULE_VERSION = ver;
@@ -285,6 +286,7 @@ test(
     t.deepEqual(c.getServiceContext(), {service: name, version: ver});
     delete process.env.GCLOUD_PROJECT;
     delete process.env.GAE_MODULE_VERSION;
+    process.env.GCLOUD_PROJECT = oldProject;
     t.end();
   }
 );

--- a/tests/unit/testUncaught.js
+++ b/tests/unit/testUncaught.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var test = require('tape');
+var isFunction = require('lodash').isFunction;
+var uncaughtSetup = require('../../lib/interfaces/uncaught.js');
+var Configuration = require('../../lib/configuration.js');
+var ErrorMessage = require('../../lib/classes/error-message.js');
+var originalHandlers = process.listeners('uncaughtException');
+var fork = require('child_process').fork;
+
+function reattachOriginalListeners ( ) {
+  for (var i = 0; i < originalHandlers.length; i++) {
+    process.on('uncaughtException', originalHandlers[i]);
+  }
+}
+
+test('Uncaught handler setup', function (t) {
+  t.throws(uncaughtSetup, undefined, 'Should throw given no configuration');
+  t.doesNotThrow(uncaughtSetup.bind(null, {}, {reportUncaughtExceptions: true}), undefined,
+    'Should not throw given valid configuration');
+  t.doesNotThrow(uncaughtSetup.bind(null, {}, {reportUncaughtExceptions: false}), undefined,
+    'Should not throw given valid configuration');
+  t.assert(process === uncaughtSetup({}, {}),
+    'Should the process on successful initialization');
+  process.removeAllListeners('uncaughtException');
+  t.deepEqual(process.listeners('uncaughtException').length, 0,
+    'There should be no listeners');
+  uncaughtSetup({}, {reportUncaughtExceptions: false});
+  t.deepEqual(process.listeners('uncaughtException').length, 0,
+    'There should be no listeners if reportUncaughtExceptions is false');
+  uncaughtSetup({}, {reportUncaughtExceptions: true});
+  t.deepEqual(process.listeners('uncaughtException').length, 1,
+    'There should be one listener if reportUncaughtExceptions is true');
+  process.removeAllListeners('uncaughtException');
+  t.end();
+});
+
+test('Test uncaught shutdown behavior', function (t) {
+  var isolate = fork('./tests/fixtures/uncaughtExitBehaviour.js', null, process.env);
+  var timeout = setTimeout(function () {
+    t.fail('Should terminate before 2500ms');
+    reattachOriginalListeners();
+    t.end();
+  }, 2500);
+  isolate.on('close', function () {
+    t.pass('Should terminate before 2500ms');
+    clearTimeout(timeout);
+    reattachOriginalListeners();
+    t.end();
+  });
+  isolate.on('error', function () {
+    console.log('got error:\n', arguments);
+    t.fail('Got an error in isolate');
+    reattachOriginalListeners();
+    t.end();
+  });
+});


### PR DESCRIPTION
Update uncaught handler to terminate on timeout #35
    
Add a setTimeout call for 2000ms to exit after a uncaught exception has
been caught when `config.reportUncaughtExceptions` is set to true. Add
tests and behaviour fixture to test full control flow from when handler
initialization to error report to process close.
    
Related issues:
Fixes #35