### PR TITLE
Update defaults for service context on Error Message #52

### DIFF
--- a/lib/classes/error-message.js
+++ b/lib/classes/error-message.js
@@ -43,8 +43,8 @@ var isObject = lodash.isObject;
  * @property {Object} serviceContext - The service information for the error
  * @property {String} serviceContext.service - The service that the error was
  *  was produced on
- * @property {String} serviceContext.version - The service version that the
- *  error was produced on
+ * @property {String|Undefined} serviceContext.version - The service version 
+ *  that the error was produced on
  * @property {String} message - The error message
  * @property {Object} context - the request, user and report context
  * @property {Object} context.httpRequest - the request context
@@ -67,7 +67,7 @@ var isObject = lodash.isObject;
 function ErrorMessage() {
 
   this.eventTime = (new Date()).toISOString();
-  this.serviceContext = {service : '', version : ''};
+  this.serviceContext = {service : 'node', version : undefined};
   this.message = '';
   this.context = {
     httpRequest : {
@@ -103,14 +103,14 @@ ErrorMessage.prototype.setEventTimeToNow = function() {
  * @function setServiceContext
  * @chainable
  * @param {String} service - the service the error was reported on
- * @param {String} version - the version the service was on when the error was
- *  reported
+ * @param {String|Undefined} version - the version the service was on when the 
+ *  error was reported
  * @returns {this} - returns the instance for chaining
  */
 ErrorMessage.prototype.setServiceContext = function(service, version) {
 
-  this.serviceContext.service = isString(service) ? service : '';
-  this.serviceContext.version = isString(version) ? version : '';
+  this.serviceContext.service = isString(service) ? service : 'node';
+  this.serviceContext.version = isString(version) ? version : undefined;
 
   return this;
 };

--- a/lib/google-apis/auth-client.js
+++ b/lib/google-apis/auth-client.js
@@ -96,7 +96,7 @@ RequestHandler.prototype.sendError = function(errorMessage, userCb) {
           'Unable to retrieve a project id from the Google Metadata Service or',
           'the local environment. Client will not be able to communicate with',
           'the Stackdriver Error Reporting API without a valid project id', 
-          'Please make sure to supply a project id either throught the'
+          'Please make sure to supply a project id either through the',
           'GCLOUD_PROJECT environmental variable or through the configuration',
           'object given to this library on startup if not running on Google',
           'Cloud Platform.'

--- a/tests/unit/testErrorMessage.js
+++ b/tests/unit/testErrorMessage.js
@@ -197,7 +197,7 @@ test(
 
     t.deepEqual(
       em.serviceContext
-      , { service: "", version: "" }
+      , { service: "node", version: undefined }
       , [
           'The service context property should have two properties:'
           , 'service and version both with a string value of: default'
@@ -317,7 +317,8 @@ test(
     var em = new ErrorMessage();
     var AFFIRMATIVE_TEST_VALUE = "VALID_INPUT_AND_TYPE";
     var DEFAULT_TEST_VALUE = "DEFAULT";
-    var DEFAULT_EM_VALUE = "";
+    var DEFAULT_VERSION_VALUE = undefined;
+    var DEFAULT_SERVICE_VALUE = "node";
 
     t.plan(10);
 
@@ -351,7 +352,7 @@ test(
     t.deepEqual(
       em.serviceContext
       , {
-        service: DEFAULT_EM_VALUE
+        service: DEFAULT_SERVICE_VALUE
         , version: AFFIRMATIVE_TEST_VALUE
       }
       , [
@@ -366,7 +367,7 @@ test(
       em.serviceContext
       , {
         service: AFFIRMATIVE_TEST_VALUE
-        , version: DEFAULT_EM_VALUE
+        , version: DEFAULT_VERSION_VALUE
       }
       , [
         "Providing only a valid value to the first argument of"
@@ -379,8 +380,8 @@ test(
     t.deepEqual(
       em.serviceContext
       , {
-        service: DEFAULT_EM_VALUE
-        , version: DEFAULT_EM_VALUE
+        service: DEFAULT_SERVICE_VALUE
+        , version: DEFAULT_VERSION_VALUE
       }
       , [
         "Providing null as the value to both arguments should set both"
@@ -392,8 +393,8 @@ test(
     t.deepEqual(
       em.serviceContext
       , {
-        service: DEFAULT_EM_VALUE
-        , version: DEFAULT_EM_VALUE
+        service: DEFAULT_SERVICE_VALUE
+        , version: DEFAULT_VERSION_VALUE
       }
       , [
         "Providing numbers as the value to both arguments should set both"
@@ -405,8 +406,8 @@ test(
     t.deepEqual(
       em.serviceContext
       , {
-        service: DEFAULT_EM_VALUE
-        , version: DEFAULT_EM_VALUE
+        service: DEFAULT_SERVICE_VALUE
+        , version: DEFAULT_VERSION_VALUE
       }
       , [
         "Providing numbers as the value to both arguments should set both"
@@ -418,8 +419,8 @@ test(
     t.deepEqual(
       em.serviceContext
       , {
-        service: DEFAULT_EM_VALUE
-        , version: DEFAULT_EM_VALUE
+        service: DEFAULT_SERVICE_VALUE
+        , version: DEFAULT_VERSION_VALUE
       }
       , [
         "Providing arrays or objects as the value to both arguments"
@@ -431,8 +432,8 @@ test(
     t.deepEqual(
       em.serviceContext
       , {
-        service: DEFAULT_EM_VALUE
-        , version: DEFAULT_EM_VALUE
+        service: DEFAULT_SERVICE_VALUE
+        , version: DEFAULT_VERSION_VALUE
       }
       , "Providing no arguments should set both properties as empty strings"
     );

--- a/tests/unit/testExtractFromErrorClass.js
+++ b/tests/unit/testExtractFromErrorClass.js
@@ -75,7 +75,7 @@ test(
   , function ( t ) {
 
     var TEST_SERVICE_VALID = {service: 'test', version: 'test'};
-    var TEST_SERVICE_DEFAULT = {service: '', version: ''};
+    var TEST_SERVICE_DEFAULT = {service: 'node', version: undefined};
     var TEST_SERVICE_INVALID = 12;
 
     t.plan(3);

--- a/tests/unit/testExtractFromObject.js
+++ b/tests/unit/testExtractFromObject.js
@@ -158,7 +158,7 @@ test(
   , function ( t ) {
 
     var TEST_SERVICE_VALID = {service: 'test', version: 'test'};
-    var TEST_SERVICE_DEFAULT = {service: '', version: ''};
+    var TEST_SERVICE_DEFAULT = {service: 'node', version: undefined};
     var TEST_SERVICE_INVALID = 12;
 
     t.plan(3);


### PR DESCRIPTION
Update the defaults on the Error Message `serviceContext` object
property to API-accepted defaults for `service` and `version`
subproperties. Set `serviceContext.service` to default to `'node'` and
`serviceContext.version` to `undefined` so that if the property remains
'unset' it will be excluded from the JSON rendering for API OTW
consumption. Fix syntax for error message production in
`auth-client.js`.

Original defaults:

```JS
{serviceContext: {service: '', version: ''}}
```

Updated defaults:

```JS
{serviceContext: {service: 'node', version: undefined}}
```

Related issues:
Fixes #52