### PR TITLE
Add log-level option to runtime configuration #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ var errors = require('@google/cloud-errors').start({
 	projectId: 'my-project-id',
 	key: 'my-api-key',
 	reportUncaughtExceptions: false, // defaults to true.
+	logLevel: 0, // defaults to logging warnings (2). Available levels: 0-5
 	serviceContext: {
 		service: 'my-service',
 		version: 'my-service-version'

--- a/index.js
+++ b/index.js
@@ -23,12 +23,16 @@ var manual = require('./lib/interfaces/manual.js');
 var express = require('./lib/interfaces/express.js');
 var restify = require('./lib/interfaces/restify');
 var uncaughtException = require('./lib/interfaces/uncaught.js');
+var createLogger = require('./lib/logger.js');
 
 /**
  * @typedef ConfigurationOptions
  * @type Object
  * @property {String} [projectId] - the projectId of the project deployed
  * @property {String} [keyFilename] - path to a key file to use for an API key
+ * @property {String|Number} logLevel - a integer between and including 0-5 or a
+ *  decimal representation of an integer including and between 0-5 in String
+ *  form
  * @property {String} [key] - API key to use for communication with the service
  * @property {uncaughtHandlingEnum}
  *  [onUncaughtException=uncaughtHandlingEnum.ignore] - one of the uncaught
@@ -62,10 +66,10 @@ var uncaughtException = require('./lib/interfaces/uncaught.js');
  *  reporting configuration
  * @returns {ApplicationErrorReportingInterface} - The error reporting interface
  */
-function initializeClientAndInterfaces ( initConfiguration ) {
-
-  var config = new Configuration(initConfiguration);
-  var client = new AuthClient(config);
+function initializeClientAndInterfaces (initConfiguration) {
+  var logger = createLogger(initConfiguration);
+  var config = new Configuration(initConfiguration, logger);
+  var client = new AuthClient(config, logger);
 
   // Setup the uncaught exception handler
   uncaughtException(client, config);

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -17,7 +17,6 @@
 'use strict';
 var env = process.env;
 var commonDiag = require('@google/cloud-diagnostics-common');
-var logger = require('./logger.js');
 var utils = commonDiag.utils;
 var lodash = require('lodash');
 var isPlainObject = lodash.isPlainObject;
@@ -48,8 +47,19 @@ var version = require('../package.json').version;
  * @param {ConfigurationOptions} givenConfig - The config given by the
  *  hosting application at runtime. Configuration values will only be observed
  *  if they are given as a plain JS object; all other values will be ignored.
+ * @param {Object} logger - The logger instance created when the library API has
+ *  been initialized.
  */
-var Configuration = function(givenConfig) {
+var Configuration = function(givenConfig, logger) {
+  /**
+   * The _logger property caches the logger instance created at the top-level
+   * for configuration logging purposes.
+   * @memberof Configuration
+   * @private
+   * @type {Object}
+   * @defaultvalue Object
+   */
+  this._logger = logger;
   /**
    * The _reportUncaughtExceptions property is meant to contain the optional
    * runtime configuration property reportUncaughtExceptions. This property will
@@ -78,7 +88,7 @@ var Configuration = function(givenConfig) {
    */
   this._shouldReportErrorsToAPI = env.NODE_ENV === 'production';
   if (!this._shouldReportErrorsToAPI) {
-    logger.warn([
+    this._logger.warn([
       'Stackdriver error reporting client has not been configured to send',
       'errors, please check the NODE_ENV environment variable and make sure it',
       'is set to production'

--- a/lib/google-apis/auth-client.js
+++ b/lib/google-apis/auth-client.js
@@ -32,8 +32,7 @@ var API = 'https://clouderrorreporting.googleapis.com/v1beta1/projects';
  * RequestHandler instance and create a new request factory for requesting
  * against the Error Reporting API.
  * @param {Configuration} - The configuration instance
- * @param {String|Null} [key] - the API key used to authenticate against the
- *  service in place of default application credentials
+ * @param {Object} logger - the logger instance
  * @class RequestHandler
  * @classdesc The RequestHandler class provides a centralized way of managing a
  * pool of ongoing requests and routing there callback execution to the right
@@ -51,10 +50,12 @@ var API = 'https://clouderrorreporting.googleapis.com/v1beta1/projects';
  *  It includes retry and authorization logic.
  * @property {String} _projectId - the project id used to uniquely identify and
  *  address the correct project in the Error Reporting API
+ * @property {Object} _logger - the instance-cached logger instance
  */
-function RequestHandler(config) {
+function RequestHandler(config, logger) {
   this._request = commonDiag.utils.authorizedRequestFactory(SCOPES);
   this._config = config;
+  this._logger = logger;
 }
 
 /**
@@ -92,7 +93,7 @@ RequestHandler.prototype.sendError = function(errorMessage, userCb) {
     self._config.getProjectId(function (err, id) {
       if (err) {
         setImmediate(function () { cb(err, null, null); });
-        logger.error([
+        self._logger.error([
           'Unable to retrieve a project id from the Google Metadata Service or',
           'the local environment. Client will not be able to communicate with',
           'the Stackdriver Error Reporting API without a valid project id', 
@@ -109,7 +110,7 @@ RequestHandler.prototype.sendError = function(errorMessage, userCb) {
         json: errorMessage
       }, function (err, response, body) {
         if (err) {
-          logger.error([
+          self._logger.error([
             'Encountered an error while attempting to transmit an error to the',
             'Stackdriver Error Reporting API.'
           ].join(' '), err);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,3 +1,8 @@
+var lodash = require('lodash');
+var isObject = lodash.isObject;
+var has = lodash.has;
+var isString = lodash.isString;
+var isNumber = lodash.isNumber;
 var logger = require('@google/cloud-diagnostics-common').logger;
 /**
  * Creates an instance of the Google Cloud Diagnostics logger class. This
@@ -7,22 +12,33 @@ var logger = require('@google/cloud-diagnostics-common').logger;
  * Order of precedence for logging level is:
  * 1) Environmental variable `GCLOUD_ERRORS_LOGLEVEL`
  * 2) Runtime configuration property `logLevel`
- * 3) Default log level of `WARN`
+ * 3) Default log level of `WARN` (2)
  * @function createLogger
- * @param {String|Number} givenLevel - a number or stringified decimal
- *  representation of a number between and including 1 through 5
+ * @param {ConfigurationOptions} initConfiguration - the desired project/error
+ *  reporting configuration. Will look for the  `logLevel` property which, if
+ *  supplied, must be a number or stringified decimal representation of a
+ *  number between and including 1 through 5
  * @returns {Object} - returns an instance of the logger created with the given/
  *  default options
  */
-function createLogger (givenLevel) {
-  var logEnv = process.env.GCLOUD_ERRORS_LOGLEVEL;
-  var logLevel = logger.warn;
-  if (!isNaN(logEnv)) {
-    logLevel = logEnv;
-  } else if (!isNaN(givenLevel)) {
-    logLevel = givenLevel;
+function createLogger (initConfiguration) {
+  // Default to log level: warn (2)
+  var level = logger.warn;
+  if (has(process.env, 'GCLOUD_ERRORS_LOGLEVEL')) {
+    // Cast env string as integer
+    level = ~~process.env.GCLOUD_ERRORS_LOGLEVEL;
+  } else if (isObject(initConfiguration) && has(initConfiguration, 'logLevel')) {
+    if (isString(initConfiguration.logLevel)) {
+      // Cast string as integer
+      level = ~~initConfiguration.logLevel;
+    } else if (isNumber(initConfiguration.logLevel)) {
+      level = initConfiguration.logLevel;
+    } else {
+      throw new Error('config.logLevel must be a number or decimal ' +
+        'representation of a number in string form');
+    }
   }
-  return logger.create(logLevel, '@google/cloud-errors');
+  return logger.create(level, '@google/cloud-errors');
 }
 
 module.exports = createLogger;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,28 @@
 var logger = require('@google/cloud-diagnostics-common').logger;
-var logConfig = process.env.GCLOUD_ERRORS_LOGLEVEL;
-var logLevel = !isNaN(logConfig) ? logConfig : logger.WARN;
-module.exports = logger.create(logLevel, '@google/cloud-errors');
+/**
+ * Creates an instance of the Google Cloud Diagnostics logger class. This
+ * instance will be configured to log at the level given by the environment or
+ * the runtime configuration property `logLevel`. If neither of these inputs are
+ * given or valid then the logger will default to logging at log level `WARN`.
+ * Order of precedence for logging level is:
+ * 1) Environmental variable `GCLOUD_ERRORS_LOGLEVEL`
+ * 2) Runtime configuration property `logLevel`
+ * 3) Default log level of `WARN`
+ * @function createLogger
+ * @param {String|Number} givenLevel - a number or stringified decimal
+ *  representation of a number between and including 1 through 5
+ * @returns {Object} - returns an instance of the logger created with the given/
+ *  default options
+ */
+function createLogger (givenLevel) {
+  var logEnv = process.env.GCLOUD_ERRORS_LOGLEVEL;
+  var logLevel = logger.warn;
+  if (!isNaN(logEnv)) {
+    logLevel = logEnv;
+  } else if (!isNaN(givenLevel)) {
+    logLevel = givenLevel;
+  }
+  return logger.create(logLevel, '@google/cloud-errors');
+}
+
+module.exports = createLogger;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "./node_modules/istanbul/lib/cli.js cover -x \"fuzzer.js\" ./node_modules/tape/bin/tape ./tests/unit/*.js",
     "integration-tests": "./node_modules/istanbul/lib/cli.js cover -x \"error-message.js\" ./node_modules/tape/bin/tape ./tests/integration/*.js",
     "style": "./node_modules/jshint/bin/jshint lib index.js",
+    "coverage": "./bin/test.sh -l",
     "coveralls": "./bin/test.sh",
     "docs": "./node_modules/.bin/jsdoc -d docs index.js lib/"
   },

--- a/tests/integration/testAuthClient.js
+++ b/tests/integration/testAuthClient.js
@@ -20,6 +20,7 @@ var nock = require('nock');
 var RequestHandler = require('../../lib/google-apis/auth-client.js');
 var ErrorMessage = require('../../lib/classes/error-message.js');
 var Configuration = require('../../lib/configuration.js');
+var createLogger = require('../../lib/logger.js');
 var lodash = require('lodash');
 var isObject = lodash.isObject;
 var isString = lodash.isString;
@@ -31,7 +32,7 @@ var client;
 test(
   'Test given valid init parameters we should be able to create a client',
   function ( t ) {
-    var cfg  = new Configuration();
+    var cfg  = new Configuration({}, createLogger({logLevel: 5}));
     if (!isString(process.env.GCLOUD_PROJECT)) {
       t.fail("The gcloud project id (GCLOUD_PROJECT) was not set as an env variable");
       t.end();
@@ -40,10 +41,12 @@ test(
       t.fail("The api key (STUBBED_API_KEY) was not set as an env variable");
       t.end();
       process.exit();
+    } else if (!isString(process.env.STUBBED_PROJECT_NUM)) {
+      t.fail('The project number (STUBBED_PROJECT_NUM) was not set as an env variable');
     }
 
     try {
-      client = new RequestHandler(cfg);
+      client = new RequestHandler(cfg, createLogger({logLevel: 5}));
     } catch (e) {
 
       t.fail("Could not init client:\n"+e);
@@ -171,7 +174,7 @@ test(
   'Given a key the client should include it as a url param on all requests',
   function (t) {
     var key = process.env.STUBBED_API_KEY
-    client = new RequestHandler(new Configuration({key: key}));
+    client = new RequestHandler(new Configuration({key: key}, createLogger({logLevel: 5})));
     var er = new Error("_@google_STACKDRIVER_INTEGRATION_TEST_ERROR__");
     var em = new ErrorMessage()
       .setMessage(er.stack);
@@ -229,7 +232,8 @@ test(
   function (t) {
     var old = process.env.NODE_ENV;
     delete process.env.NODE_ENV;
-    client = new RequestHandler(new Configuration());
+    var l = createLogger({logLevel: 5});
+    client = new RequestHandler(new Configuration(undefined, l), createLogger({logLevel: 5}));
     client.sendError({}, function (err, response, body){
       t.assert(
         err instanceof Error,
@@ -263,8 +267,8 @@ test(
     var er = new Error("_@google_STACKDRIVER_INTEGRATION_TEST_API_KEY_ERROR__");
     var em = new ErrorMessage()
       .setMessage(er.stack);
-    var cfg = new Configuration();
-    client = new RequestHandler(cfg);
+    var cfg = new Configuration(undefined, createLogger({logLevel: 5}));
+    client = new RequestHandler(cfg, createLogger({logLevel: 5}));
     client.sendError(em, function (err, response, body) {
       t.assert(
         err instanceof Error,
@@ -294,10 +298,11 @@ test(
     var oldKey = process.env.STUBBED_API_KEY;
     delete process.env.GCLOUD_PROJECT;
     delete process.env.STUBBED_API_KEY;
-     var cfg  = new Configuration({projectId: process.env.STUBBED_PROJECT_NUM});
+     var cfg  = new Configuration({projectId: process.env.STUBBED_PROJECT_NUM},
+      createLogger({logLevel: 5}));
 
     try {
-      client = new RequestHandler(cfg);
+      client = new RequestHandler(cfg, createLogger({logLevel: 5}));
     } catch (e) {
 
       t.fail("Could not init client:\n"+e);

--- a/tests/unit/testLogger.js
+++ b/tests/unit/testLogger.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+var test = require('tape');
+var lodash = require('lodash');
+var createLogger = require('../../lib/logger.js');
+
+test('Initializing the logger', function (t) {
+  var oldEnv = process.env.GCLOUD_ERRORS_LOGLEVEL;
+  delete process.env.GCLOUD_ERRORS_LOGLEVEL;
+  t.doesNotThrow(createLogger, createLogger(),
+    'Does not throw given undefined');
+  t.doesNotThrow(createLogger.bind(null, {}), createLogger(),
+    'Does not throw given an empty object');
+  t.doesNotThrow(
+    createLogger.bind(null, {logLevel: 3}), 
+    createLogger({logLevel: 3}),
+    'Does not throw given a valid configuration object with a valid log level'
+  );
+  t.doesNotThrow(
+    createLogger.bind(null, {logLevel: '3'}),
+    createLogger({logLevel: '3'}),
+    ['Does not throw given a valid configuration object with a valid log level',
+    'in string form'].join(' ')
+  );
+  t.throws(
+    createLogger.bind(null, {logLevel: null}),
+    undefined,
+    ['Throws given a configuration object with the logLevel key specified that',
+    'is not of the correct type'].join(' ')
+  );
+  process.env.GCLOUD_ERRORS_LOGLEVEL = 4;
+  t.doesNotThrow(
+    createLogger,
+    createLogger({logLevel: 4}),
+    ['Does not throw given only the environment configuration variable for log',
+    'level setting'].join(' ')
+  );
+  process.env.GCLOUD_ERRORS_LOGLEVEL = oldEnv;
+  t.end();
+});


### PR DESCRIPTION
Add the `logLevel` property to the runtime configuration and modify
the logger creation flow to parse this option second (if applicable)
after the environmental `GCLOUD_ERRORS_LOGLEVEL` level variable
and to use a singular instance of the logger class upon library
init. Add corresponding tests and update documentation accordingly.
Add a script to `package.json` for easy coverage without coveralls:
`npm run-script coverage`.

**Original config object:**

```JS
var errors = require('@google/cloud-errors').start({
  projectId: 'my-project-id',
  key: 'my-api-key',
  reportUncaughtExceptions: false, // defaults to true.
  serviceContext: {
    service: 'my-service',
    version: 'my-service-version'
  }
});
```

**Updated configuration object:**
*Notice the `logLevel` property*

```JS
var errors = require('@google/cloud-errors').start({
  projectId: 'my-project-id',
  key: 'my-api-key',
  reportUncaughtExceptions: false, // defaults to true.
  logLevel: 0, // defaults to logging warnings
  serviceContext: {
    service: 'my-service',
    version: 'my-service-version'
  }
});
```

Related issues:
Fixes #51