### PR TITLE
Add error stack substitution to string handler

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -135,7 +135,7 @@ var Configuration = function(givenConfig, logger) {
    * @private
    * @type {Object}
    */
-  this._serviceContext = {service: '', version: ''};
+  this._serviceContext = {service: 'nodejs', version: ''};
   /**
    * The _version of the Error reporting library that is currently being run.
    * This information will be logged in errors communicated to the Stackdriver

--- a/lib/error-handlers/string.js
+++ b/lib/error-handlers/string.js
@@ -30,12 +30,16 @@ var isString = require('lodash').isString;
  */
 function handleStringAsError(err, errorMessage) {
   var fauxError = new Error();
-  var errChecked = fauxError.stack;
+  var fullStack = fauxError.stack.split('\n');
+  var cleanedStack = fullStack.slice(0, 1).concat(fullStack.slice(4));
+  var errChecked = '';
 
   if (isString(err)) {
-
-    errChecked = err;
+    // Replace the generic error message with the user-provided string
+    cleanedStack[0] = err;
   }
+
+  errChecked = cleanedStack.join('\n');
 
   errorMessage.setMessage(errChecked);
 }

--- a/tests/test-servers/manual_scaffold_server.js
+++ b/tests/test-servers/manual_scaffold_server.js
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 var errors = require('../../index.js').start();
-var r = errors.report('Sample string', (err, result) => {
-  console.log('callback from report', err, result);
+var r = errors.report('Sample test string', (err, response, body) => {
+  console.log(
+    'Callback from report:\n',
+    '\tError: ', err, '\n', 
+    '\tResponse Body:', body
+  );
 });
 
 var express = require('express');


### PR DESCRIPTION
Add logic to provide error stacks for basic non-
error string tokens given as error values. Update
the test-servers/manual_scaffold_server.js test
file to use this new pattern.

Related Issues:
Fixes #41  