### PR TITLE
Test Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ node_js:
 - '5'
 - '6'
 script:
-- npm run-script coveralls
+- npm run-script test

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -87,7 +87,7 @@ var Configuration = function(givenConfig, logger) {
    * @type {Boolean}
    */
   this._shouldReportErrorsToAPI = env.NODE_ENV === 'production';
-  if (!this._shouldReportErrorsToAPI) {
+  if (!this._shouldReportErrorsToAPI && this._logger) {
     this._logger.warn([
       'Stackdriver error reporting client has not been configured to send',
       'errors, please check the NODE_ENV environment variable and make sure it',

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -20,7 +20,6 @@ var commonDiag = require('@google/cloud-diagnostics-common');
 var utils = commonDiag.utils;
 var lodash = require('lodash');
 var isPlainObject = lodash.isPlainObject;
-var isFunction = lodash.isFunction;
 var isBoolean = lodash.isBoolean;
 var isString = lodash.isString;
 var isNumber = lodash.isNumber;
@@ -87,7 +86,7 @@ var Configuration = function(givenConfig, logger) {
    * @type {Boolean}
    */
   this._shouldReportErrorsToAPI = env.NODE_ENV === 'production';
-  if (!this._shouldReportErrorsToAPI && this._logger) {
+  if (!this._shouldReportErrorsToAPI) {
     this._logger.warn([
       'Stackdriver error reporting client has not been configured to send',
       'errors, please check the NODE_ENV environment variable and make sure it',

--- a/lib/interfaces/express.js
+++ b/lib/interfaces/express.js
@@ -16,7 +16,6 @@
 
 'use strict';
 var lodash = require('lodash');
-var isFunction = lodash.isFunction;
 var isObject = lodash.isObject;
 var isFunction = lodash.isFunction;
 var ErrorMessage = require('../classes/error-message.js');

--- a/lib/interfaces/uncaught.js
+++ b/lib/interfaces/uncaught.js
@@ -57,7 +57,7 @@ function handlerSetup(client, config) {
     setTimeout(handleProcessExit, 2000);
   }
 
-  if (config.reportUncaughtExceptions === false) {
+  if (!config.getReportUncaughtExceptions()) {
     // Do not attach a listener to the process
     return null;
   }

--- a/lib/interfaces/uncaught.js
+++ b/lib/interfaces/uncaught.js
@@ -32,7 +32,7 @@ function handleProcessExit() { process.exit(1); }
  * @function handlerSetup
  * @param {AuthClient} client - the API client for communication with the
  *  Stackdriver Error API
- * @param {NormalizedConfigurationVariables} config - the init configuration
+ * @param {Configuration} config - the init configuration
  * @returns {Null|process} - Returns null if the config demands ignoring
  * uncaught
  *  exceptions, otherwise return the process instance

--- a/tests/fixtures/configuration.js
+++ b/tests/fixtures/configuration.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Configuration = require('../../lib/configuration.js');
+
+var FakeConfiguration = function(config) {
+  return Configuration.bind(this)(config, { warn: function () {} });
+};
+
+FakeConfiguration.prototype = Object.create(Configuration.prototype);
+
+module.exports = FakeConfiguration;

--- a/tests/fixtures/configuration.js
+++ b/tests/fixtures/configuration.js
@@ -17,7 +17,7 @@
 var Configuration = require('../../lib/configuration.js');
 
 var FakeConfiguration = function(config) {
-  return Configuration.bind(this)(config, { warn: function () {} });
+  return Configuration.call(this, config, { warn: function () {} });
 };
 
 FakeConfiguration.prototype = Object.create(Configuration.prototype);

--- a/tests/fixtures/uncaughtExitBehaviour.js
+++ b/tests/fixtures/uncaughtExitBehaviour.js
@@ -18,9 +18,8 @@ var uncaughtSetup = require('../../lib/interfaces/uncaught.js');
 var test = require('tape');
 var nock = require('nock');
 var isString = require('lodash').isString;
-var Configuration = require('../../lib/configuration.js');
+var Configuration = require('../fixtures/configuration.js');
 var RequestHandler = require('../../lib/google-apis/auth-client.js');
-var ErrorMessage = require('../../lib/classes/error-message.js');
 var originalHandlers = process.listeners('uncaughtException');
 
 function reattachOriginalListeners ( ) {

--- a/tests/integration/testAuthClient.js
+++ b/tests/integration/testAuthClient.js
@@ -19,13 +19,12 @@ var test = require('tape');
 var nock = require('nock');
 var RequestHandler = require('../../lib/google-apis/auth-client.js');
 var ErrorMessage = require('../../lib/classes/error-message.js');
-var Configuration = require('../../lib/configuration.js');
+var Configuration = require('../fixtures/configuration.js');
 var createLogger = require('../../lib/logger.js');
 var lodash = require('lodash');
 var isObject = lodash.isObject;
 var isString = lodash.isString;
 var isEmpty = lodash.isEmpty;
-var has = lodash.has;
 var client;
 
 

--- a/tests/unit/testConfiguration.js
+++ b/tests/unit/testConfiguration.js
@@ -18,16 +18,15 @@
 var test = require('tape');
 var lodash = require('lodash');
 var isNumber = lodash.isNumber;
-var Configuration = require('../../lib/configuration.js');
+var Configuration = require('../fixtures/configuration.js');
 var version = require('../../package.json').version;
 var Fuzzer = require('../../utils/fuzzer.js');
-var cd = require('@google/cloud-diagnostics-common');
 var level = process.env.GCLOUD_DEBUG_LOGLEVEL;
 var logger = require('../../lib/logger.js')({
   logLevel: isNumber(level) ? level : 4
 });
 var nock = require('nock');
-var METADATA_URL = 'http://metadata.google.internal/computeMetadata/v1';
+var METADATA_URL = 'http://metadata.google.internal/computeMetadata/v1/project';
 
 test(
   'Initing an instance of Configuration should return a Configuration instance',
@@ -100,9 +99,7 @@ test(
   function (t) {
     var oldProject = process.env.GCLOUD_PROJECT;
     delete process.env.GCLOUD_PROJECT;
-    var s = nock(
-     'http://metadata.google.internal/computeMetadata/v1/project'
-    ).get('/project-id').times(1).reply(500);
+    var s = nock(METADATA_URL).get('/project-id').times(1).reply(500);
     var c = new Configuration(undefined, logger);
     c.getProjectId(function (err, id) {
       t.assert(err instanceof Error);
@@ -122,9 +119,7 @@ test(
     delete process.env.GCLOUD_PROJECT;
     var projectNumber = 1234;
     var c = new Configuration({projectId: projectNumber}, logger);
-    var s = nock(
-     'http://metadata.google.internal/computeMetadata/v1/project'
-    ).get('/project-id').times(1).reply(500);
+    var s = nock(METADATA_URL).get('/project-id').times(1).reply(500);
     c.getProjectId(function (err, id) {
       t.deepEqual(err, null);
       t.deepEqual(id, projectNumber.toString());
@@ -143,9 +138,7 @@ test(
     delete process.env.GCLOUD_PROJECT;
     var projectNumber = null;
     var c = new Configuration({projectId: projectNumber}, logger);
-    var s = nock(
-     'http://metadata.google.internal/computeMetadata/v1/project'
-    ).get('/project-id').times(1).reply(500);
+    var s = nock(METADATA_URL).get('/project-id').times(1).reply(500);
     c.getProjectId(function (err, id) {
       t.assert(err instanceof Error);
       t.deepEqual(id, null);
@@ -164,9 +157,7 @@ test(
     delete process.env.GCLOUD_PROJECT;
     var projectNumber = '1234';
     var c = new Configuration({projectId: projectNumber}, logger);
-    var s = nock(
-     'http://metadata.google.internal/computeMetadata/v1/project'
-    ).get('/project-id').times(1).reply(500);
+    var s = nock(METADATA_URL).get('/project-id').times(1).reply(500);
     c.getProjectId(function (err, id) {
       t.deepEqual(null, err);
       t.deepEqual(id, projectNumber);
@@ -207,9 +198,7 @@ test(
     var projectNumber = '1234';
     process.env.GCLOUD_PROJECT = projectNumber;
     var c = new Configuration(undefined, logger);
-    var s = nock(
-     'http://metadata.google.internal/computeMetadata/v1/project'
-    ).get('/project-id').times(1).reply(500);
+    var s = nock(METADATA_URL).get('/project-id').times(1).reply(500);
     c.getProjectId(function (err, id) {
       t.deepEqual(null, err);
       t.deepEqual(id, projectNumber);
@@ -228,9 +217,7 @@ test(
     delete process.env.GCLOUD_PROJECT;
     var projectId = 'test-123';
     var c = new Configuration({projectId: projectId}, logger);
-    var s = nock(
-     'http://metadata.google.internal/computeMetadata/v1/project'
-    ).get('/project-id').times(1).reply(500);
+    var s = nock(METADATA_URL).get('/project-id').times(1).reply(500);
     c.getProjectId(function (err, id) {
       t.deepEqual(err, null);
       t.deepEqual(id, projectId);
@@ -324,9 +311,8 @@ test(
   'instance with number as id',
   function (t) {
     var id = '1234';
-    var s = nock(
-     'http://metadata.google.internal/computeMetadata/v1/project'
-    ).get('/project-id').times(1).reply(200, id);
+    var s = nock(METADATA_URL).get('/project-id').times(1)
+      .reply(200, id);
     var c = new Configuration(undefined, logger);
     c.getProjectId(function (err, num) {
       t.deepEqual(err, null);
@@ -341,9 +327,8 @@ test(
   'instance with string as id',
   function (t) {
     var projectId = 'test-project-id';
-    var s = nock(
-     'http://metadata.google.internal/computeMetadata/v1/project'
-    ).get('/project-id').times(1).reply(200, projectId);
+    var s = nock(METADATA_URL).get('/project-id').times(1)
+      .reply(200, projectId);
     var c = new Configuration(undefined, logger);
     c.getProjectId(function (err, id) {
       t.deepEqual(err, null);

--- a/tests/unit/testExpressInterface.js
+++ b/tests/unit/testExpressInterface.js
@@ -20,7 +20,7 @@ var merge = lodash.merge;
 var expressInterface = require('../../lib/interfaces/express.js');
 var ErrorMessage = require('../../lib/classes/error-message.js');
 var Fuzzer = require('../../utils/fuzzer.js');
-var Configuration = require('../../lib/configuration.js');
+var Configuration = require('../fixtures/configuration.js');
 
 test(
   "Given invalid, variable input the express interface handler setup should not throw errors"

--- a/tests/unit/testHapiInterface.js
+++ b/tests/unit/testHapiInterface.js
@@ -17,14 +17,13 @@
 var lodash = require('lodash');
 var isFunction = lodash.isFunction;
 var isPlainObject = lodash.isPlainObject;
-var isString = lodash.isString;
 var has = lodash.has;
 var test = require('tape');
 var hapiInterface = require('../../lib/interfaces/hapi.js');
 var ErrorMessage = require('../../lib/classes/error-message.js');
 var Fuzzer = require('../../utils/fuzzer.js');
 var EventEmitter = require('events').EventEmitter;
-var Configuration = require('../../lib/configuration.js');
+var Configuration = require('../fixtures/configuration.js');
 
 test(
   "Given invalid, variable input the hapi interface handler setup should not throw errors"

--- a/tests/unit/testManualHandler.js
+++ b/tests/unit/testManualHandler.js
@@ -39,7 +39,7 @@ test('Test manual handler interface', function(t) {
 test('single string argument is accepted', function(t) {
   var r = report('doohickey');
   t.ok(r instanceof ErrorMessage, 'should be an instance of ErrorMessage');
-  t.equal(r.message, 'doohickey', 'string error should propagate');
+  t.ok(r.message.match(/doohickey/), 'string error should propagate');
   t.end();
 });
 
@@ -53,7 +53,7 @@ test('callback function should get called', function(t) {
   var r = report('malarkey', function(err, res) {
     t.end();
   });
-  t.equal(r.message, 'malarkey', 'string error should propagate');
+  t.ok(r.message.match(/malarkey/), 'string error should propagate');
 });
 
 test('calls without any arguments work', function(t) {
@@ -99,7 +99,8 @@ test('missing additional message', function(t) {
   var r = report('ticky', { method: 'TACKEY' }, function(err, res) {
     t.end();
   });
-  t.equal(r.message, 'ticky', 'original message should be preserved');
+  t.ok(r.message.match(/ticky/) && !r.message.match(/TACKEY/),
+    'original message should be preserved');
   t.equal(r.context.httpRequest.method, 'TACKEY');
 });
 
@@ -107,21 +108,22 @@ test('arguments after callback function should get ignored', function(t) {
   var r = report('hockey', function(err, res) {
     t.end();
   }, 'field');
-  t.equal(r.message, 'hockey', 'string after callback should be ignored');
+  t.ok(r.message.match('hockey') && !r.message.match('field'),
+    'string after callback should be ignored');
 });
 
 test('null arguments in the middle', function(t) {
   var r = report('pokey', null, null, function(err, res) {
     t.end();
   });
-  t.equal(r.message, 'pokey', 'string error should propagate');
+  t.ok(r.message.match(/pokey/), 'string error should propagate');
 });
 
 test('undefined arguments in the middle', function(t) {
   var r = report('Turkey', undefined, undefined, function(err, res) {
     t.end();
   });
-  t.equal(r.message, 'Turkey', 'string error should propagate');
+  t.ok(r.message.match(/Turkey/), 'string error should propagate');
 });
 
 test('undefined request', function(t) {
@@ -135,7 +137,8 @@ test('undefined additional message', function(t) {
   var r = report('Mickey', { method: 'SNIFF'}, undefined, function(err, res) {
     t.end();
   });
-  t.equal(r.message, 'Mickey', 'string error should propagate');
+  t.ok(r.message.match(/Mickey/) && !r.message.match(/SNIFF/),
+    'string error should propagate');
   t.equal(r.context.httpRequest.method, 'SNIFF');
 });
 

--- a/tests/unit/testManualHandler.js
+++ b/tests/unit/testManualHandler.js
@@ -16,7 +16,7 @@
 
 var test = require('tape');
 var manual = require('../../lib/interfaces/manual.js');
-var Configuration = require('../../lib/configuration.js');
+var Configuration = require('../fixtures/configuration.js');
 var config = new Configuration({});
 var ErrorMessage = require('../../lib/classes/error-message.js');
 

--- a/tests/unit/testRestifyInterface.js
+++ b/tests/unit/testRestifyInterface.js
@@ -19,6 +19,13 @@ var test = require('tape');
 var restifyInterface = require('../../lib/interfaces/restify.js');
 var UNCAUGHT_EVENT = 'uncaughtException';
 
+// node v0.12 compatibility
+if (!EventEmitter.prototype.listenerCount) {
+  EventEmitter.prototype.listenerCount = function(eventName) {
+    return EventEmitter.listenerCount(this, eventName);
+  }
+}
+
 test('Attachment of the server object to uncaughtException', function (t) {
   var ee = new EventEmitter;
   t.plan(2);

--- a/tests/unit/testUncaught.js
+++ b/tests/unit/testUncaught.js
@@ -16,11 +16,9 @@
 
 var test = require('tape');
 var lodash = require('lodash');
-var isFunction = lodash.isFunction;
 var isString = lodash.isString;
 var uncaughtSetup = require('../../lib/interfaces/uncaught.js');
-var Configuration = require('../../lib/configuration.js');
-var ErrorMessage = require('../../lib/classes/error-message.js');
+var Configuration = require('../fixtures/configuration.js');
 var originalHandlers = process.listeners('uncaughtException');
 var fork = require('child_process').fork;
 

--- a/tests/unit/testUncaught.js
+++ b/tests/unit/testUncaught.js
@@ -30,21 +30,29 @@ function reattachOriginalListeners ( ) {
   }
 }
 
+// Returns a Configuration object with given value for reportUncaughtExceptions,
+// and dummy logger
+function getConfig(reportUncaughtExceptions) {
+  return new Configuration({
+    reportUncaughtExceptions: reportUncaughtExceptions
+  });
+}
+
 test('Uncaught handler setup', function (t) {
   t.throws(uncaughtSetup, undefined, 'Should throw given no configuration');
-  t.doesNotThrow(uncaughtSetup.bind(null, {}, {reportUncaughtExceptions: true}), undefined,
+  t.doesNotThrow(uncaughtSetup.bind(null, {}, getConfig(true)), undefined,
     'Should not throw given valid configuration');
-  t.doesNotThrow(uncaughtSetup.bind(null, {}, {reportUncaughtExceptions: false}), undefined,
+  t.doesNotThrow(uncaughtSetup.bind(null, {}, getConfig(false)), undefined,
     'Should not throw given valid configuration');
-  t.assert(process === uncaughtSetup({}, {}),
-    'Should the process on successful initialization');
+  t.assert(process === uncaughtSetup({}, getConfig(true)),
+    'Should return the process on successful initialization');
   process.removeAllListeners('uncaughtException');
   t.deepEqual(process.listeners('uncaughtException').length, 0,
     'There should be no listeners');
-  uncaughtSetup({}, {reportUncaughtExceptions: false});
+  uncaughtSetup({}, getConfig(false));
   t.deepEqual(process.listeners('uncaughtException').length, 0,
     'There should be no listeners if reportUncaughtExceptions is false');
-  uncaughtSetup({}, {reportUncaughtExceptions: true});
+  uncaughtSetup({}, getConfig(true));
   t.deepEqual(process.listeners('uncaughtException').length, 1,
     'There should be one listener if reportUncaughtExceptions is true');
   process.removeAllListeners('uncaughtException');


### PR DESCRIPTION
The Travis CI build is incorrectly configured to swallow the `tape` exit code, so it always passes.

This change addresses this by modifying the Travis config file and fixing broken tests that went undetected.