### PR TITLE
Add keyFilename/credentials to config object and README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ If your application is running outside of Google Cloud Platform, such as locally
 
 On Google App Engine, these environment variables are already set.
 
+## Configuration
+
+The following code snippet lists all available configuration options. All configuration options are optional.
+
+```js
+var errors = require('@google/cloud-errors').start({
+    projectId: 'my-project-id',
+    keyFilename: '/path/to/keyfile.json',
+    credentials: require('./path/to/keyfile.json'),
+    key: 'my-api-key', // if specified, uses this value to authenticate each request individually.
+    reportUncaughtExceptions: false, // defaults to true.
+    logLevel: 0, // defaults to logging warnings (2). Available levels: 0-5
+    serviceContext: {
+        service: 'my-service',
+        version: 'my-service-version'
+    }
+});
+```
+
 ## Examples
 
 ### Using Express

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stackdriver Error Reporting agent for Node.js
+# Stackdriver Error Reporting Agent for Node.js
 
 [![Build Status](https://travis-ci.org/GoogleCloudPlatform/cloud-errors-nodejs.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/cloud-errors-nodejs)
 [![Coverage Status](https://coveralls.io/repos/github/GoogleCloudPlatform/cloud-errors-nodejs/badge.svg?branch=coveralls)](https://coveralls.io/github/GoogleCloudPlatform/cloud-errors-nodejs?branch=coveralls)
@@ -73,30 +73,26 @@ If your application is running outside of Google Cloud Platform, such as locally
 
         GCLOUD_PROJECT=particular-future-12345 node myapp.js
 
-1. You need to provide service account credentials to your application. The recommended way is via [Application Default Credentials][app-default-credentials].
+1. You need to provide service account credentials to your application.
+  * The recommended way is via [Application Default Credentials][app-default-credentials].\
+    1. [Create a new JSON service account key][service-account].
+    1. Copy the key somewhere your application can access it. Be sure not to expose the key publicly.
+    1. Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the full path to the key. The trace agent will automatically look for this environment variable.
+  * If you are running your application on a development machine or test environment where you are using the [`gcloud` command line tools][gcloud-sdk], and are logged using `gcloud beta auth application-default login`, you already have sufficient credentials, and a service account key is not required.
+  * Alternatively, you may set the `keyFilename` or `credentials` configuration field to the full path or contents to the key file, respectively. Setting either of these fields will override either setting `GOOGLE_APPLICATION_CREDENTIALS` or logging in using `gcloud`. For example:
 
-  1. [Create a new JSON service account key][service-account].
-  1. Copy the key somewhere your application can access it. Be sure not to expose the key publicly.
-  1. Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the full path to the key. The trace agent will automatically look for this environment variable.
+    ```JS
+    // Require and start the agent with configuration options
+    var errors = require('@google/cloud-errors').start({
+      // The path to your key file:
+      keyFilename: '/path/to/keyfile.json',
 
-If you are running your application on a development machine or test environment where you are using the [`gcloud` command line tools][gcloud-sdk], and are logged using `gcloud beta auth application-default login`, you already have sufficient credentials, and a service account key is not required.
-
-Alternatively, you may set the `keyFilename` or `credentials` configuration field to the full path or contents to the key file, respectively. Setting either of these fields will override either setting `GOOGLE_APPLICATION_CREDENTIALS` or logging in using `gcloud`. (See the [default configuration](config.js) for more details.)
+      // Or the contents of the key file:
+      credentials: require('./path/to/keyfile.json')
+    });
+    ```
 
 On Google App Engine, these environment variables are already set.
-
-```JS
-var errors = require('@google/cloud-errors').start({
-	projectId: 'my-project-id',
-	key: 'my-api-key',
-	reportUncaughtExceptions: false, // defaults to true.
-	logLevel: 0, // defaults to logging warnings (2). Available levels: 0-5
-	serviceContext: {
-		service: 'my-service',
-		version: 'my-service-version'
-	}
-});
-```
 
 ## Examples
 
@@ -225,3 +221,7 @@ git commit
 ```
 
 *Then commit your changes and make a pull-request*
+
+[gcloud-sdk]: https://cloud.google.com/sdk/gcloud/
+[app-default-credentials]: https://developers.google.com/identity/protocols/application-default-credentials
+[service-account]: https://console.developers.google.com/apis/credentials/serviceaccountkey

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stackdriver Error Reporting Agent for Node.js
+# Node.js module for Stackdriver Error Reporting
 
 [![Build Status](https://travis-ci.org/GoogleCloudPlatform/cloud-errors-nodejs.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/cloud-errors-nodejs)
 [![Coverage Status](https://coveralls.io/repos/github/GoogleCloudPlatform/cloud-errors-nodejs/badge.svg?branch=coveralls)](https://coveralls.io/github/GoogleCloudPlatform/cloud-errors-nodejs?branch=coveralls)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Node.js module for Stackdriver Error Reporting
+# Stackdriver Error Reporting agent for Node.js
 
 [![Build Status](https://travis-ci.org/GoogleCloudPlatform/cloud-errors-nodejs.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/cloud-errors-nodejs)
 [![Coverage Status](https://coveralls.io/repos/github/GoogleCloudPlatform/cloud-errors-nodejs/badge.svg?branch=coveralls)](https://coveralls.io/github/GoogleCloudPlatform/cloud-errors-nodejs?branch=coveralls)
@@ -21,7 +21,7 @@ applications running in almost any environment. Here's an introductory video:
 1. [Enable the Stackdriver Error Reporting API](https://console.cloud.google.com/apis/api/clouderrorreporting.googleapis.com/overview) for your project.
 1. The module will only send errors when the `NODE_ENV` environment variable is set to `production`.
 
-## Quickstart on Google Cloud Platform
+## Quick Start
 
 1. **Install the module:**
 
@@ -47,16 +47,41 @@ applications running in almost any environment. Here's an introductory video:
 
   Open Stackdriver Error Reporting at https://console.cloud.google.com/errors to view the reported errors.
 
-## Setup
+## Running on Google Cloud Platform
 
-When initing the Stackdriver Error Reporting library you must specify the following:
+There are three different services that can host Node.js application to Google Cloud Platform.
 
-* **Authentication**: Use one of the following:
-  * **(recommended)** a path to your keyfile in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable,
-  * a path to your keyfile in the `keyFilename` argument,
-  * an [API key](https://support.google.com/cloud/answer/6158862) string in the `key` argument.
-* **projectId**: either using the `GLCOUD_PROJECT` environment variable or the `projectId` argument.
-* **service**: either using the `GAE_MODULE_NAME`  environment variable or the `serviceContext.service` argument.
+### Google App Engine flexible environment
+
+If you are using [Google App Engine flexible environment](https://cloud.google.com/appengine/docs/flexible/), you do not have to do any additional configuration.
+
+### Google Compute Engine
+
+Your VM instances need to be created with the `https://www.googleapis.com/auth/cloud-platform` scope if created via the [gcloud](https://cloud.google.com/sdk) CLI or the Google Cloud Platform API, or by enabling at least one of the Stackdriver APIs if created through the browser-based console.
+
+If you already have VMs that were created without API access and do not wish to recreate it, you can follow the instructions for using a service account under [running elsewhere](#running-elsewhere).
+
+### Google Container Engine
+
+Container Engine nodes need to also be created with the `https://www.googleapis.com/auth/cloud-platform` scope, which is configurable during cluster creation. Alternatively, you can follow the instructions for using a service account under [running elsewhere](#running-elsewhere). It's recommended that you store the service account credentials as [Kubernetes Secret](http://kubernetes.io/v1.1/docs/user-guide/secrets.html).
+
+## Running elsewhere
+
+If your application is running outside of Google Cloud Platform, such as locally, on-premise, or on another cloud provider, you can still use Stackdriver Errors.
+
+1. You will need to specify your project ID when starting the errors agent.
+
+        GCLOUD_PROJECT=particular-future-12345 node myapp.js
+
+1. You need to provide service account credentials to your application. The recommended way is via [Application Default Credentials][app-default-credentials].
+
+  1. [Create a new JSON service account key][service-account].
+  1. Copy the key somewhere your application can access it. Be sure not to expose the key publicly.
+  1. Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the full path to the key. The trace agent will automatically look for this environment variable.
+
+If you are running your application on a development machine or test environment where you are using the [`gcloud` command line tools][gcloud-sdk], and are logged using `gcloud beta auth application-default login`, you already have sufficient credentials, and a service account key is not required.
+
+Alternatively, you may set the `keyFilename` or `credentials` configuration field to the full path or contents to the key file, respectively. Setting either of these fields will override either setting `GOOGLE_APPLICATION_CREDENTIALS` or logging in using `gcloud`. (See the [default configuration](config.js) for more details.)
 
 On Google App Engine, these environment variables are already set.
 
@@ -72,6 +97,8 @@ var errors = require('@google/cloud-errors').start({
 	}
 });
 ```
+
+## Examples
 
 ### Using Express
 
@@ -158,7 +185,7 @@ server.head('/hello/:name', respond);
 server.listen(8080);
 ```
 
-## Developing the library
+## Contributing changes
 
 Install the dependencies:
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ applications running in almost any environment. Here's an introductory video:
 
 ## Running on Google Cloud Platform
 
-There are three different services that can host Node.js application to Google Cloud Platform.
-
 ### Google App Engine flexible environment
 
 If you are using [Google App Engine flexible environment](https://cloud.google.com/appengine/docs/flexible/), you do not have to do any additional configuration.

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -126,6 +126,28 @@ var Configuration = function(givenConfig, logger) {
    */
   this._key = null;
   /**
+   * The _keyFilename property is meant to contain a path to a file containing
+   * user or service account credentials, which will be used in place of
+   * application default credentials. This property will remain null if no
+   * value for keyFilename is given in the runtime configuration.
+   * @memberof Configuration
+   * @private
+   * @type {String|Null}
+   * @defaultvalue null
+   */
+  this._keyFilename = null;
+  /**
+   * The _credentials property is meant to contain an object representation of
+   * user or service account credentials, which will be used in place of
+   * application default credentials. This property will remain null if no
+   * value for credentials is given in the runtime configuration.
+   * @memberof Configuration
+   * @private
+   * @type {Credentials|Null}
+   * @defaultvalue null
+   */
+  this._credentials = null;
+  /**
    * The _serviceContext property is meant to contain the optional service
    * context information which may be given in the runtime configuration. If
    * not given in the runtime configuration then the property value will remain
@@ -217,6 +239,16 @@ Configuration.prototype._gatherLocalConfiguration = function() {
     this._key = this._givenConfiguration.key;
   } else if (has(this._givenConfiguration, 'key')) {
     throw new Error('config.key must be a string');
+  }
+  if (isString(this._givenConfiguration.keyFilename)) {
+    this._keyFilename = this._givenConfiguration.keyFilename;
+  } else if (has(this._givenConfiguration, 'keyFilename')) {
+    throw new Error('config.keyFilename must be a string');
+  }
+  if (isPlainObject(this._givenConfiguration.credentials)) {
+    this._credentials = this._givenConfiguration.credentials;
+  } else if (has(this._givenConfiguration, 'credentials')) {
+    throw new Error('config.credentials must be a valid credentials object');
   }
 };
 /**
@@ -321,6 +353,26 @@ Configuration.prototype.getProjectId = function(cb) {
  */
 Configuration.prototype.getKey = function() {
   return this._key;
+};
+/**
+ * Returns the _keyFilename property on the instance.
+ * @memberof Configuration
+ * @public
+ * @function getKeyFilename
+ * @returns {String|Null} - returns the _keyFilename property
+ */
+Configuration.prototype.getKeyFilename = function() {
+  return this._keyFilename;
+};
+/**
+ * Returns the _credentials property on the instance.
+ * @memberof Configuration
+ * @public
+ * @function getCredentials
+ * @returns {Credentials\Null} - returns the _credentials property
+ */
+Configuration.prototype.getCredentials = function() {
+  return this._credentials;
 };
 /**
  * Returns the _serviceContext property on the instance.

--- a/lib/google-apis/auth-client.js
+++ b/lib/google-apis/auth-client.js
@@ -31,7 +31,7 @@ var API = 'https://clouderrorreporting.googleapis.com/v1beta1/projects';
  * The RequestHandler constructor initializes several properties on the
  * RequestHandler instance and create a new request factory for requesting
  * against the Error Reporting API.
- * @param {Configuration} - The configuration instance
+ * @param {Configuration} config - The configuration instance
  * @param {Object} logger - the logger instance
  * @class RequestHandler
  * @classdesc The RequestHandler class provides a centralized way of managing a
@@ -53,7 +53,10 @@ var API = 'https://clouderrorreporting.googleapis.com/v1beta1/projects';
  * @property {Object} _logger - the instance-cached logger instance
  */
 function RequestHandler(config, logger) {
-  this._request = commonDiag.utils.authorizedRequestFactory(SCOPES);
+  this._request = commonDiag.utils.authorizedRequestFactory(SCOPES, {
+    keyFile: config.getKeyFilename(),
+    credentials: config.getCredentials()
+  });
   this._config = config;
   this._logger = logger;
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tape": "^4.5.1"
   },
   "dependencies": {
-    "@google/cloud-diagnostics-common": "0.2.5",
+    "@google/cloud-diagnostics-common": "0.3.0",
     "lodash": "^4.13.1"
   }
 }

--- a/tests/fixtures/gcloud-credentials.json
+++ b/tests/fixtures/gcloud-credentials.json
@@ -1,0 +1,6 @@
+{
+  "client_id": "x",
+  "client_secret": "y",
+  "refresh_token": "z",
+  "type": "authorized_user"
+}

--- a/tests/unit/testConfigCredentials.js
+++ b/tests/unit/testConfigCredentials.js
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var test = require('tape');
+var path = require('path');
+var nock = require('nock');
+var http = require('http');
+var express = require('express');
+
+var originalHandlers = process.listeners('uncaughtException');
+
+function reattachOriginalListeners() {
+  for (var i = 0; i < originalHandlers.length; i++) {
+    process.on('uncaughtException', originalHandlers[i]);
+  }
+}
+
+process.env.GCLOUD_PROJECT = '0';
+process.env.NODE_ENV = 'production';
+
+test('Should use the keyFilename field of the config object', function(t) {
+  process.removeAllListeners('uncaughtException');
+  var credentials = require('../fixtures/gcloud-credentials.json');
+  var config = {
+    keyFilename: path.join('tests', 'fixtures', 'gcloud-credentials.json'),
+    reportUncaughtExceptions: false
+  };
+  var agent = require('../..').start(config);
+  var app = express();
+  app.use('/', function () {
+    throw '0';
+  });
+  app.use(agent.express);
+  var server = app.listen(3000, function() {
+    nock.disableNetConnect();
+    nock.enableNetConnect('localhost');
+    var scope = nock('https://accounts.google.com')
+      .intercept('/o/oauth2/token', 'POST', function(body) {
+        t.equal(body.client_id, credentials.client_id);
+        t.equal(body.client_secret, credentials.client_secret);
+        t.equal(body.refresh_token, credentials.refresh_token);
+        return true;
+      }).reply(200, {
+        refresh_token: 'hello',
+        access_token: 'goodbye',
+        expiry_date: new Date(9999, 1, 1)
+      });
+
+    // Since we have to get an auth token, this always gets intercepted second
+    nock('https://clouderrorreporting.googleapis.com/v1beta1/projects')
+      .post('/0/events:report', function() {
+        t.true(scope.isDone());
+        nock.cleanAll();
+        server.close();
+        reattachOriginalListeners();
+        t.end();
+        return true;
+      }).reply(200);
+
+    http.get({port: 3000, path: '/'}, function(res) {});
+  });
+});
+
+test('should use the credentials field of the config object', function(t) {
+  process.removeAllListeners('uncaughtException');
+  var config = {
+    credentials: require('../fixtures/gcloud-credentials.json'),
+    reportUncaughtExceptions: false
+  };
+  var agent = require('../..').start(config);
+  var app = express();
+  app.use('/', function () {
+    throw '0';
+  });
+  app.use(agent.express);
+  var server = app.listen(3000, function() {
+    nock.disableNetConnect();
+    nock.enableNetConnect('localhost');
+    var scope = nock('https://accounts.google.com')
+      .intercept('/o/oauth2/token', 'POST', function(body) {
+        t.equal(body.client_id, config.credentials.client_id);
+        t.equal(body.client_secret, config.credentials.client_secret);
+        t.equal(body.refresh_token, config.credentials.refresh_token);
+        return true;
+      }).reply(200, {
+        refresh_token: 'hello',
+        access_token: 'goodbye',
+        expiry_date: new Date(9999, 1, 1)
+      });
+
+    // Since we have to get an auth token, this always gets intercepted second
+    nock('https://clouderrorreporting.googleapis.com/v1beta1/projects')
+      .post('/0/events:report', function() {
+        t.true(scope.isDone());
+        nock.cleanAll();
+        server.close();
+        reattachOriginalListeners();
+        t.end();
+        return true;
+      }).reply(200);
+
+    http.get({port: 3000, path: '/'}, function(res) {});
+  });
+});
+
+test('Should ignore credentials if keyFilename is provided', function(t) {
+  process.removeAllListeners('uncaughtException');
+  var correctCredentials = require('../fixtures/gcloud-credentials.json');
+  var config = {
+    keyFilename: path.join('tests', 'fixtures', 'gcloud-credentials.json'),
+    credentials: {
+      client_id: 'a',
+      client_secret: 'b',
+      refresh_token: 'c',
+      type: 'authorized_user'
+    },
+    reportUncaughtExceptions: true
+  };
+  ['client_id', 'client_secret', 'refresh_token'].forEach(function (field) {
+    t.true(correctCredentials.hasOwnProperty(field));
+    t.true(config.credentials.hasOwnProperty(field));
+    t.notEqual(config.credentials[field],
+      correctCredentials[field]);
+  });
+  var agent = require('../..').start(config);
+  var app = express();
+  app.use('/', function () {
+    throw '0';
+  });
+  app.use(agent.express);
+  var server = app.listen(3000, function() {
+    nock.disableNetConnect();
+    nock.enableNetConnect('localhost');
+    var scope = nock('https://accounts.google.com')
+      .intercept('/o/oauth2/token', 'POST', function(body) {
+        t.equal(body.client_id, correctCredentials.client_id);
+        t.equal(body.client_secret, correctCredentials.client_secret);
+        t.equal(body.refresh_token, correctCredentials.refresh_token);
+        return true;
+      }).reply(200, {
+        refresh_token: 'hello',
+        access_token: 'goodbye',
+        expiry_date: new Date(9999, 1, 1)
+      });
+
+    // Since we have to get an auth token, this always gets intercepted second
+    nock('https://clouderrorreporting.googleapis.com/v1beta1/projects')
+      .post('/0/events:report', function() {
+        t.true(scope.isDone());
+        nock.cleanAll();
+        server.close();
+        reattachOriginalListeners();
+        t.end();
+        return true;
+      }).reply(200);
+
+    http.get({port: 3000, path: '/'}, function(res) {});
+  });
+});


### PR DESCRIPTION
Add keyFilename and credentials to the config object passed in through "start()", akin to:

https://github.com/GoogleCloudPlatform/cloud-debug-nodejs/pull/169
https://github.com/GoogleCloudPlatform/cloud-trace-nodejs/pull/315

In addition, README.md reflects these changes, and some parts are elaborated upon to be more similar to the READMEs in other agents.