### PR TITLE
Add error message builder and parse capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ var errors = require('@google/cloud-errors')({
 
 ## Examples
 
+### Reporting Manually
+
+```JS
+var errors = require('@google/cloud-errors').start();
+// Use the error message builder to custom set all message fields
+var errorEvt = errors.event()
+  .setMessage('My error message')
+  .setUser('root@nexus');
+errors.report(errorEvt, () => console.log('done!'));
+// Or just use a regular error
+errors.report(new Error('My error message'), () => console.log('done!'));
+// One can even just use a string
+errors.report('My error message');
+```
+
 ### Using Express
 
 ```JS

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ var hapi = require('./src/interfaces/hapi.js');
 var manual = require('./src/interfaces/manual.js');
 var express = require('./src/interfaces/express.js');
 var restify = require('./src/interfaces/restify');
+var messageBuilder = require('./src/interfaces/message-builder.js');
 var uncaughtException = require('./src/interfaces/uncaught.js');
 var createLogger = require('./src/logger.js');
 
@@ -65,6 +66,7 @@ var createLogger = require('./src/logger.js');
  *  Stackdriver Error Reporting Service
  * @property {Function} express - The express plugin for Stackdriver Error
  *  Reporting
+ * @property {Function} message - Returns a new ErrorMessage class instance
  */
 
 // TODO: Update this documentation
@@ -96,6 +98,7 @@ function Errors(initConfiguration) {
   this.report = manual(client, config);
   this.express = express(client, config);
   this.restify = restify(client, config);
+  this.event = messageBuilder(config);
 
   if (koa) {
     this.koa = koa(client, config);

--- a/src/interfaces/manual.js
+++ b/src/interfaces/manual.js
@@ -40,9 +40,10 @@ function handlerSetup(client, config) {
   /**
    * The interface for manually reporting errors to the Google Error API in
    * application code.
-   * @param {Any} err - error information of any type or content. This can be
-   *  of any type but better errors will be logged given a valid instance of
-   *  Error class.
+   * @param {Any|ErrorMessage} err - error information of any type or content.
+   *  This can be of any type but by giving an instance of ErrorMessage as the
+   *  error arugment one can manually provide values to all fields of the
+   *  potential payload.
    * @param {Object} [request] - an object containing request information. This
    *  is expected to be an object similar to the Node/Express request object.
    * @param {String} [additionalMessage] - a string containing error message
@@ -54,6 +55,7 @@ function handlerSetup(client, config) {
    * the parameters given.
    */
   function reportManualError(err, request, additionalMessage, callback) {
+    var em;
     if (config.lacksCredentials()) {
       return;
     }
@@ -74,11 +76,14 @@ function handlerSetup(client, config) {
       additionalMessage = undefined;
     }
 
-    var em = new ErrorMessage();
-    em.setServiceContext(config.getServiceContext().service,
-                         config.getServiceContext().version);
-
-    errorHandlerRouter(err, em);
+    if (err instanceof ErrorMessage) {
+      em = err;
+    } else {
+      em = new ErrorMessage();
+      em.setServiceContext(config.getServiceContext().service,
+                          config.getServiceContext().version);
+      errorHandlerRouter(err, em);
+    }
 
     if (isObject(request)) {
       em.consumeRequestInformation(manualRequestInformationExtractor(request));

--- a/src/interfaces/message-builder.js
+++ b/src/interfaces/message-builder.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+var ErrorMessage = require('../classes/error-message.js');
+
+/**
+ * The handler setup function serves to produce a bound instance of the
+ * of a factory for ErrorMessage class instances with configuration-supplied
+ * service contexts automatically set.
+ * @function handlerSetup
+ * @param {NormalizedConfigurationVariables} config - the environmental
+ *  configuration
+ * @returns {ErrorMessage} - a new ErrorMessage instance
+ */
+function handlerSetup(config) {
+  /**
+   * The interface for creating new instances of the ErrorMessage class which
+   * can be used to send custom payloads to the Error reporting service.
+   * @returns {ErrorMessage} - returns a new instance of the ErrorMessage class
+   */
+  function newMessage() {
+    return new ErrorMessage().setServiceContext(
+                         config.getServiceContext().service,
+                         config.getServiceContext().version);
+  }
+
+  return newMessage;
+}
+
+module.exports = handlerSetup;

--- a/tests/unit/testManualHandler.js
+++ b/tests/unit/testManualHandler.js
@@ -133,4 +133,51 @@ describe('Manual handler', function () {
       assert.strictEqual(r.context.httpRequest.method, 'SNIFF');
     });
   });
+
+  describe('Custom Payload Builder', function () {
+    it('Should accept builder instance as only argument', function () {
+      var msg = 'test';
+      var r = report(new ErrorMessage().setMessage(msg));
+      assert.strictEqual(r.message, msg, 
+        'string message should propagate from error message instance');
+    });
+    it('Should accept builder and request as arguments', function () {
+      var msg = 'test';
+      var oldReq = {method: 'GET'};
+      var newReq = {method: 'POST'};
+      var r = report(
+        new ErrorMessage().setMessage(msg).consumeRequestInformation(oldReq),
+        newReq
+      );
+      assert.strictEqual(r.message, msg, 
+        'string message should propagate from error message instance');
+      assert.strictEqual(r.context.httpRequest.method, newReq.method,
+        [
+          'request argument supplied at report invocation should propagte and, if',
+          'supplied, should overwrite any prexisting data in the field.'
+        ].join('\n')
+      );
+    });
+    it('Should accept message and additional message params as arguments', function () {
+      var oldMsg = 'test';
+      var newMsg = 'analysis';
+      var r = report(
+        new ErrorMessage().setMessage(oldMsg),
+        newMsg
+      );
+      assert.strictEqual(r.message, newMsg, 
+        [
+          'message argument supplied at report invocation should propagte and, if',
+          'supplied, should overwrite any prexisting data in the message field.'
+        ].join('\n'));
+    });
+    it('Should accept message and callback function as arguments', function (done) {
+      var oldMsg = 'test';
+      var newMsg = 'analysis';
+      var r = report(
+        new ErrorMessage().setMessage(oldMsg),
+        function () { done(); }
+      );
+    });
+  });
 });


### PR DESCRIPTION
Add a function exposed on the top-level export
of the library which allows for creation of new
ErrorMessage class instances for direct use and
modification by application code.

Additionally, add capability to the manual handler
to specifically accept error message class instances
and not apply general object handling. This means
that if a user supplies only an error message instance
the instance will be accepted wholesale and queued for
submission to the service without modification.

Example invocation:

```JS
var errors = require(...).start();

var em = errors.event()
  .setMessage('three token string')
  .setUser('user');
// The same variadic argument structure applies
errors.report(em, () => console.log('done!'));
```

@ofrobots @matthewloring  ptal