### PR TITLE
Add force flag option to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ var errors = require('@google/cloud-errors').start({
     keyFilename: '/path/to/keyfile.json',
     credentials: require('./path/to/keyfile.json'),
     key: 'my-api-key', // if specified, uses this value to authenticate each request individually.
+    ignoreEnvironmentCheck: true, // if set to true library will report errors to the service regardless of env
     reportUncaughtExceptions: false, // defaults to true.
     logLevel: 0, // defaults to logging warnings (2). Available levels: 0-5
     serviceContext: {

--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ var createLogger = require('./lib/logger.js');
  *  running on
  * @property {String} [serviceContext.version] - the version the hosting
  *  application is currently labelled as
+ * @property {Boolean} [ignoreEnvironmentCheck] - flag indicating whether or not
+ *  to communicate errors to the Stackdriver service even if NODE_ENV is not set
+ *  to production
  */
 
 /**

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -77,22 +77,16 @@ var Configuration = function(givenConfig, logger) {
    * the Stackdriver error reporting library will actually try to report Errors
    * to the Stackdriver Error API. The value of this property is derived from
    * the `NODE_ENV` environmental variable. If the `NODE_ENV` variable is set to
-   * 'production' then the _shouldReportErrorToAPI property will be set to true
+   * 'production' then the _shouldReportErrorsToAPI property will be set to true
    * and error reporting library will attempt to send errors to the Error API.
    * Otherwise the value will remain false and errors will not be reported to
    * the API.
    * @memberof Configuration
    * @private
    * @type {Boolean}
+   * @defaultvalue false
    */
-  this._shouldReportErrorsToAPI = env.NODE_ENV === 'production';
-  if (!this._shouldReportErrorsToAPI) {
-    this._logger.warn([
-      'Stackdriver error reporting client has not been configured to send',
-      'errors, please check the NODE_ENV environment variable and make sure it',
-      'is set to production'
-    ].join(' '));
-  }
+  this._shouldReportErrorsToAPI = false;
   /**
    * The _projectId property is meant to contain the string project id that the
    * hosting application is running under. The project id is a unique string
@@ -229,6 +223,22 @@ Configuration.prototype._checkLocalServiceContext = function() {
  * @returns {Undefined} - does not return anything
  */
 Configuration.prototype._gatherLocalConfiguration = function() {
+  if (this._givenConfiguration.ignoreEnvironmentCheck === true) {
+    this._shouldReportErrorsToAPI = true;
+  } else if (has(this._givenConfiguration, 'ignoreEnvironmentCheck') 
+    && !isBoolean(this._givenConfiguration.ignoreEnvironmentCheck)) {
+      throw new Error('config.ignoreEnvironmentCheck must be a boolean');
+  } else {
+    this._shouldReportErrorsToAPI = env.NODE_ENV === 'production';
+  }
+  if (!this._shouldReportErrorsToAPI) {
+    this._logger.warn([
+      'Stackdriver error reporting client has not been configured to send',
+      'errors, please check the NODE_ENV environment variable and make sure it',
+      'is set to "production" or the ignoreEnvironmentCheck property is set to',
+      'true in the runtime configuration object'
+    ].join(' '));
+  }
   if (isBoolean(this._givenConfiguration.reportUncaughtExceptions)) {
     this._reportUncaughtExceptions = this._givenConfiguration
       .reportUncaughtExceptions;

--- a/lib/google-apis/auth-client.js
+++ b/lib/google-apis/auth-client.js
@@ -125,7 +125,8 @@ RequestHandler.prototype.sendError = function(errorMessage, userCb) {
     cb(new Error([
       'Stackdriver error reporting client has not been configured to send',
       'errors, please check the NODE_ENV environment variable and make sure it',
-      'is set to production'
+      'is set to "production" or set the ignoreEnvironmentCheck property to ',
+      'true in the runtime configuration object'
     ].join(' ')), null, null);
   }
 };

--- a/tests/unit/testConfiguration.js
+++ b/tests/unit/testConfiguration.js
@@ -59,7 +59,8 @@ test(
     t.deepEqual(c._reportUncaughtExceptions, true);
     t.deepEqual(c.getReportUncaughtExceptions(), true);
     t.deepEqual(c._shouldReportErrorsToAPI, false, 
-      "_shouldReportErrorsToAPI should init to false if env !== production");
+      "_shouldReportErrorsToAPI should init to false if env !== production "+
+      "and the force flag is not set tot true");
     t.deepEqual(c.getShouldReportErrorsToAPI(), false);
     t.deepEqual(c._projectId, null);
     t.deepEqual(c._key, null);
@@ -68,6 +69,13 @@ test(
     t.deepEqual(c.getServiceContext(), {service: '', version: ''});
     t.deepEqual(c._version, version);
     t.deepEqual(c.getVersion(), version);
+    stubConfig.ignoreEnvironmentCheck = true;
+    c = new Configuration(stubConfig, logger);
+    t.deepEqual(c.getShouldReportErrorsToAPI(), true, 
+      'ignoreEnvironmentCheck flag should set the report errors to api flag '+
+      'true even if env is not set production');
+    delete stubConfig.ignoreEnvironmentCheck;
+    c = new Configuration(stubConfig, logger);
     c.getProjectId(function (err, id) {
       t.assert(err instanceof Error);
       t.deepEqual(id, null);
@@ -89,6 +97,8 @@ test(
       'Should throw when not given a string for serviceContext.service');  
     t.throws(function () { new Configuration({serviceContext: {version: true}}, logger) },
       'Should throw when not given a string for serviceContext.version');
+    t.throws(function () {new Configuration({ignoreEnvironmentCheck: null}, logger)},
+      'Should throw if given an invalid type for ignoreEnvironmentCheck')
     t.doesNotThrow(function () { new Configuration({serviceContext: {}}, logger) },
       'Should not throw when given an empty object');
   }


### PR DESCRIPTION
Add a optional boolean flag option to the configuration which
allows for the configuration of the library to send errors to
the Stackdriver service regardless of env configuration.

fixes #79 