### PR TITLE
Update configuration.js, README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ applications running in almost any environment. Here's an introductory video:
 1. Your application needs to use Node.js version 0.12 or greater.
 1. You need a [Google Cloud project](https://console.cloud.google.com). Your application can run anywhere, but errors are reported to a particular project.
 1. [Enable the Stackdriver Error Reporting API](https://console.cloud.google.com/apis/api/clouderrorreporting.googleapis.com/overview) for your project.
-1. The module will only send errors when the `NODE_ENV` environment variable is set to `production`.
+1. The module will only send errors when the `NODE_ENV` environment variable is 
+set to `production` or the `ignoreEnvironmentCheck` property given in the
+runtime configuration object is set to `true`.
 
 ## Quick Start
 
@@ -104,10 +106,18 @@ var errors = require('@google/cloud-errors').start({
     projectId: 'my-project-id',
     keyFilename: '/path/to/keyfile.json',
     credentials: require('./path/to/keyfile.json'),
-    key: 'my-api-key', // if specified, uses this value to authenticate each request individually.
-    ignoreEnvironmentCheck: true, // if set to true library will report errors to the service regardless of env
-    reportUncaughtExceptions: false, // defaults to true.
-    logLevel: 0, // defaults to logging warnings (2). Available levels: 0-5
+    // if specified, uses this value to authenticate each request individually
+    key: 'my-api-key',
+    // if true library will attempt to report errors to the service regardless
+    // of the value of NODE_ENV
+    // defaults to false
+    ignoreEnvironmentCheck: false,
+    // determines if the library will attempt to report uncaught exceptions
+    // defaults to true
+    reportUncaughtExceptions: true,
+    // determines the logging level internal to the library; levels range 0-5
+    // defaults to 2 (warnings)
+    logLevel: 2, 
     serviceContext: {
         service: 'my-service',
         version: 'my-service-version'

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -76,11 +76,12 @@ var Configuration = function(givenConfig, logger) {
    * The _shouldReportErrorsToAPI property is meant to denote whether or not
    * the Stackdriver error reporting library will actually try to report Errors
    * to the Stackdriver Error API. The value of this property is derived from
-   * the `NODE_ENV` environmental variable. If the `NODE_ENV` variable is set to
-   * 'production' then the _shouldReportErrorsToAPI property will be set to true
-   * and error reporting library will attempt to send errors to the Error API.
-   * Otherwise the value will remain false and errors will not be reported to
-   * the API.
+   * the `NODE_ENV` environmental variable or the value of the ignoreEnvironmentCheck
+   * property if present in the runtime configuration. If either the `NODE_ENV` 
+   * variable is set to 'production' or the ignoreEnvironmentCheck propery on 
+   * the runtime configuration is set to true then the error reporting library will 
+   * attempt to send errors to the Error API. Otherwise the value will remain 
+   * false and errors will not be reported to the API.
    * @memberof Configuration
    * @private
    * @type {Boolean}


### PR DESCRIPTION
Update description of `_shouldReportErrorsToAPI` and how value is derived
in `configuration.js`. Update line in `README.md` stating that only a production
`NODE_ENV` variable was required for service error reporting to also include 
that new runtime property `ignoreEnvironmentCheck` can be used to override
environment-wide runtime configurations..
Update sample runtime configuration snippet to be more consistent
in describing some properties and their default values.