### PR TITLE
Add koa@next support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ app.use(function *(){
 app.listen(3000);
 ```
 
+### Using koa@next
+
+```JS
+const errors = require('@google/cloud-errors')();
+const Koa = require('koa');
+const app = new Koa();
+
+// Will attach to 'error' event which includes
+// request/response lifecycle errors
+errors.koaNext(app);
+
+app.use(ctx => ctx.body = 'Hello World!');
+app.listen(3000);
+```
+
 ### Using Restify
 
 ```JS

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ var AuthClient = require('./src/google-apis/auth-client.js');
 // Begin error reporting interfaces
 
 var koa = useKoa ? require('./src/interfaces/koa.js') : null;
+var koaNext = useKoa ? require('./src/interfaces/koaNext.js') : null;
 var hapi = require('./src/interfaces/hapi.js');
 var manual = require('./src/interfaces/manual.js');
 var express = require('./src/interfaces/express.js');
@@ -99,6 +100,7 @@ function Errors(initConfiguration) {
 
   if (koa) {
     this.koa = koa(client, config);
+    this.koaNext = koaNext(client, config);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lodash.without": "^4.4.0",
     "mocha": "^3.2.0",
     "nock": "^9.0.0",
+    "npm-install-version": "^6.0.1",
     "nyc": "^10.0.0",
     "restify": "^4.1.0",
     "tape": "^4.5.1"

--- a/src/interfaces/koaNext.js
+++ b/src/interfaces/koaNext.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+var ErrorMessage = require('../classes/error-message.js');
+var koaRequestInformationExtractor = require('../request-extractors/koa.js');
+var errorHandlerRouter = require('../error-router.js');
+
+/**
+ * The koaNextErrorHandler function is a wrapper function which provides the
+ * user-interface function with the configuration information and client
+ * machinery to talk to the Stackdriver error reporting service.
+ * @function koaNextErrorHandler
+ * @param {AuthClient} - The API client instance to report errors to Stackdriver
+ * @param {NormalizedConfigurationVariables} - The application configuration
+ * @returns {Function} - The function used to catch errors yielded by downstream
+ *  request handlers.
+ */
+function koaNextErrorHandler(client, config) {
+
+  /**
+   * The actual error handler for the Koa plugin attempts to catch the results
+   * of downstream request handlers by attaching to the error event on the
+   * koa app instance. This handler should be invoked with a koa app instance
+   * as early as possible so that errors can be caught as early as possible.
+   * @param {Error} err - the error which occurred
+   * @param {Object} [ctx] - the request/response context if applicable
+   * @returns {Undefined} does not return anything
+   */
+  return function (app) {
+    if (config.lacksCredentials()) {
+      return;
+    }
+    app.on('error', function (err, ctx) {
+      var svc = config.getServiceContext();
+      var em = new ErrorMessage().setServiceContext(svc.service, svc.version);
+      if (ctx) {
+        em.consumeRequestInformation(
+          koaRequestInformationExtractor(ctx.request, ctx.response));
+      }
+      errorHandlerRouter(err, em);
+      client.sendError(em);
+    });
+  };
+}
+
+module.exports = koaNextErrorHandler;

--- a/tests/test-servers/koaNext_scaffold_server.js
+++ b/tests/test-servers/koaNext_scaffold_server.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const PORT = 3000;
+const niv = require('npm-install-version');
+niv.install('koa@2.0');
+const Koa = niv.require('koa@2.0');
+const app = new Koa();
+const errorHandler = require('../../index.js')({
+  ignoreEnvironmentCheck: true,
+  serviceContext: {
+    service: 'my-service-123',
+    version: 'my-service-version-123'
+  }
+});
+
+errorHandler.koaNext(app);
+
+app.use(function (ctx, next) {
+  //This will set status and message
+  ctx.status = 500;
+  ctx.message = 'Three token string';
+  throw new Error('Three token string');
+  return next();
+});
+
+
+// response
+app.use(function (ctx){
+  ctx.body = 'Hello World';
+});
+
+app.listen(PORT);
+console.log('Server listening @', PORT);

--- a/tests/unit/testKoaNextInterface.js
+++ b/tests/unit/testKoaNextInterface.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var EventEmitter = require('events').EventEmitter;
+var assert = require('assert');
+var merge = require('lodash.merge');
+var koaNext = require('../../src/interfaces/koaNext.js');
+var ErrorMessage = require('../../src/classes/error-message.js');
+var Configuration = require('../fixtures/configuration.js');
+var createLogger = require('../../src/logger.js');
+
+function noOp () {
+  return;
+}
+
+describe('koaNext interface', function () {
+  before(function () {
+    try {
+      createDeferredPromise();
+    } catch (e) {
+      this.skip(
+        'Skipping koaNext interface testing due to lack of promise support');
+    }
+  });
+  describe('Intended behaviour', function () {
+    var stubbedConfig = new Configuration({
+      serviceContext: {
+        service: "a_test_service"
+        , version: "a_version"
+      }
+    }, createLogger({logLevel: 4}));
+    var stubbedCtx = {
+      request: {
+        method: 'GET',
+        url: '/route',
+        ip: '::1',
+        headers: {
+          'user-agent': 'Something akin to Mozilla',
+          referrer: 'http://www.reddit.com/r/netsec/'
+        }
+      },
+      response: {
+        status: 200
+      }
+    };
+    stubbedConfig.lacksCredentials = function () {
+      return false;
+    };
+    var client = {
+      sendError: noOp
+    };
+    var testError = new Error("This is a test");
+    var validBoundHandler = koaNext(client, stubbedConfig);
+    var stubApp = new EventEmitter();
+    afterEach(function () {
+      client.sendError = noOp;
+      stubApp.removeAllListeners();
+    });
+    it('Should catch the error with context', function (done) {
+      client.sendError = function (em) {
+        assert.deepEqual(em,
+          merge(
+            new ErrorMessage().setMessage(testError.stack)
+              .setServiceContext(stubbedConfig._serviceContext.service,
+                stubbedConfig._serviceContext.version)
+              .setHttpMethod(stubbedCtx.request.method).setUrl(stubbedCtx.request.url)
+              .setRemoteIp(stubbedCtx.request.ip)
+              .setUserAgent(stubbedCtx.request.headers['user-agent'])
+              .setReferrer(stubbedCtx.request.headers.referrer)
+              .setResponseStatusCode(stubbedCtx.response.status),
+            {eventTime: em.eventTime}
+          )
+        );
+        done();
+      };
+      var validBoundHandler = koaNext(client, stubbedConfig);
+      validBoundHandler(stubApp);
+      setImmediate(function () {stubApp.emit('error', testError, stubbedCtx)});
+    });
+    it('Should catch the error without context', function (done) {
+      client.sendError = function (em) {
+        assert.deepEqual(em,
+          merge(
+            new ErrorMessage().setMessage(testError.stack)
+              .setServiceContext(stubbedConfig._serviceContext.service,
+                stubbedConfig._serviceContext.version),
+            {eventTime: em.eventTime}
+          )
+        );
+        done();
+      };
+      var validBoundHandler = koaNext(client, stubbedConfig);
+      validBoundHandler(stubApp);
+      setImmediate(function () {stubApp.emit('error', testError)});
+    });
+    it('Should not attach if lacking credentials', function (done) {
+      // Make sure to override client.lacksCredentials
+      stubbedConfig.lacksCredentials = function () {return true;};
+      client.sendError = function (em) {
+        assert(false, 'It should not attach and call send error');
+        done();
+      };
+      var validBoundHandler = koaNext(client, stubbedConfig);
+      validBoundHandler(stubApp);
+      setImmediate(function () {
+        stubApp.on('error', function (e) {
+          // Stub the error handler so it doesn't throw
+        });
+        stubApp.emit('error', testError);
+        setTimeout(function () {
+          done();
+        }, 50);
+      });
+    });
+  });
+});


### PR DESCRIPTION
  - Add interface for koa@next through .koaNext
    method property.
  - Add documentation to readme and new code.
  - Add tests and server scaffolds.
  - Add `npm-install-version` as development
    dependency to use koa@next scaffolds.