### PR TITLE
Fix serviceContext propagation in uncaught reporting

### DIFF
--- a/src/interfaces/uncaught.js
+++ b/src/interfaces/uncaught.js
@@ -51,6 +51,8 @@ function handlerSetup(client, config) {
    */
   function uncaughtExceptionHandler(err) {
     var em = new ErrorMessage();
+    em.setServiceContext(config.getServiceContext().service,
+                        config.getServiceContext().version);
     errorHandlerRouter(err, em);
     client.sendError(em, handleProcessExit);
     setTimeout(handleProcessExit, 2000);


### PR DESCRIPTION
Fixes #101 -- bug where service-context provided during
runtime configuration does not propagate to error messages
created in the uncaughtException behaviour path.

cc @kilianc